### PR TITLE
Simulated lighting for ambient only VRC worlds

### DIFF
--- a/ELDistanceFunctions.cginc
+++ b/ELDistanceFunctions.cginc
@@ -462,7 +462,32 @@ float sdSpiral(float3 p, float thickness, float height, float a, float b, float 
 
     return max(dist / thickness, abs(p.z) - height);
 }
+float sdKnighty(float3 p, float i0)
+{
+    const float minsx[5] = {-.3252, -1.05,-1.21,-1.04,-0.737};
+    const float minsy[5] = {-.7862, -1.05,-.954,-.79,-0.73};
+    const float minsz[5] = {-.0948, -0.0001,-.0001,-.126,-1.23};
+    const float minsw[5] = {.678, .7,1.684,.833, .627};
+    const float maxsx[5] = {.3457, 1.05,.39,.3457,.73};
+    const float maxsy[5] = {1.0218, 1.05,.65,1.0218,0.73};
+    const float maxsz[5] = {1.2215, 1.27,1.27,1.2215,.73};
+    const float maxsw[5] = {.9834, .95,2.74,.9834, .8335};
 
+    float4 mins = float4(minsx[i0], minsy[i0], minsz[i0], minsw[i0]);
+    float4 maxs = float4(maxsx[i0], maxsy[i0], maxsz[i0], maxsw[i0]);
+
+    float k = 0.0;
+    float scale=1.0;
+    for (int i=0; i < 5; i++)
+    {
+        p = 2.0 * clamp(p, mins.xyz, maxs.xyz) - p;
+        k = max(mins.w / dot(p,p), 1.0);
+        p *= k;
+        scale *= k;
+    }
+    float rxy = length(p.xy);
+    return 0.7 * max(rxy - maxs.w, rxy * p.z / length(p)) / scale;
+}
 
 float udTriangle(float3 pos, float3 a, float3 b, float3 c)
 {

--- a/ELMathUtilities.cginc
+++ b/ELMathUtilities.cginc
@@ -132,7 +132,7 @@ float3 ELHueShift (in float3 color, in float3 shift) {
     float3 p = float3(0.55735,0.55735,0.55735) * (float3(0.55735,0.55735,0.55735),color);
     float3 u = color - p;
     float3 v = cross(float3(0.55735,0.55735,0.55735),u);
-    color = u*cos(shift*0.2832) + v*sin(shift*0.2832) + p;
+    color = u*cos(shift*6.2832) + v*sin(shift*6.2832) + p;
     return color;
 }
 

--- a/ELMathUtilities.cginc
+++ b/ELMathUtilities.cginc
@@ -133,6 +133,7 @@ float3 ELHueShift (in float3 color, in float3 shift) {
     float3 u = color - p;
     float3 v = cross(float3(0.55735,0.55735,0.55735),u);
     color = u*cos(shift*0.2832) + v*sin(shift*0.2832) + p;
+    return color;
 }
 
 #endif // EL_MATH_UTILITIES_CGINC_

--- a/ELMathUtilities.cginc
+++ b/ELMathUtilities.cginc
@@ -128,4 +128,11 @@ float ELSmootherStep(float edge0, float edge1, float x)
     return x * x * x * (x * (x * 6.0 - 15.0) + 10.0);
 }
 
+float3 ELHueShift (in float3 color, in float3 shift) {
+    float3 p = float3(0.55735,0.55735,0.55735) * (float3(0.55735,0.55735,0.55735),color);
+    float3 u = color - p;
+    float3 v = cross(float3(0.55735,0.55735,0.55735),u);
+    color = u*cos(shift*0.2832) + v*sin(shift*0.2832) + p;
+}
+
 #endif // EL_MATH_UTILITIES_CGINC_

--- a/ELRaycastBase.cginc
+++ b/ELRaycastBase.cginc
@@ -44,7 +44,12 @@ ELRaycastBaseFragmentInput ELRaycastBaseVertex(ELRaycastBaseVertexInput input)
         output.objectRayOrigin = ELWorldToObjectPos(UNITY_MATRIX_I_V._m03_m13_m23);
         output.objectRayDirection = input.objectPos - output.objectRayOrigin;
     }
-
+    #ifdef DYNAMICLIGHTMAP_ON
+        o.lmap.zw = v.texcoord2.xy * unity_DynamicLightmapST.xy + unity_DynamicLightmapST.zw;
+    #endif
+    #ifdef LIGHTMAP_ON
+        o.lmap.xy = v.texcoord1.xy * unity_LightmapST.xy + unity_LightmapST.zw;
+    #endif
     #if !defined(SPHERICAL_HARMONICS_PER_PIXEL)
         #ifndef LIGHTMAP_ON
             #if UNITY_SHOULD_SAMPLE_SH

--- a/ELRaycastBase.cginc
+++ b/ELRaycastBase.cginc
@@ -88,7 +88,7 @@ ELRaycastBaseFragmentInput ELRaycastBaseVertex(ELRaycastBaseVertexInput input)
  *        later used in {@link ELDecodeMaterial}.
  * @return {@code true} if the ray hit. {@code false} otherwise.
  */
-bool ELRaycast(ELRay ray, out float3 objectPos, out float3 objectNormal, out float material, out uint its);
+bool ELRaycast(ELRay ray, out float3 objectPos, out float3 objectNormal, out float material, out uint its, out float reach);
 
 /**
  * _Pseudo-abstract method, to be implemented by consumers._
@@ -112,9 +112,9 @@ void ELDecodeMaterial(ELRaycastBaseFragmentInput input, float material, inout Su
  *        later used in {@link ELDecodeMaterial}.
  * @return {@code true} if the ray hit, {@code false} otherwise.
  */
-bool ELFragmentRaycast(ELRaycastBaseFragmentInput input, out float3 objectPos, out float3 objectNormal, out float material, out uint its)
+bool ELFragmentRaycast(ELRaycastBaseFragmentInput input, out float3 objectPos, out float3 objectNormal, out float material, out uint its, out float reach)
 {
-    return ELRaycast(ELGetRay(input), objectPos, objectNormal, material, its);
+    return ELRaycast(ELGetRay(input), objectPos, objectNormal, material, its, reach);
 }
 
 /**
@@ -133,7 +133,8 @@ SurfaceOutputStandard ELRaycastSurface(ELRaycastBaseFragmentInput input, out flo
 {
     float material;
     uint iters = 0;
-    bool hit = ELFragmentRaycast(input, objectPos, objectNormal, material, iters);
+    float r = 0.;
+    bool hit = ELFragmentRaycast(input, objectPos, objectNormal, material, iters, r);
 
     // Save lighting calculations when not hit
     UNITY_BRANCH
@@ -144,6 +145,7 @@ SurfaceOutputStandard ELRaycastSurface(ELRaycastBaseFragmentInput input, out flo
     }
 
     input.its = iters;
+    input.reach = r;
     SurfaceOutputStandard output;
     UNITY_INITIALIZE_OUTPUT(SurfaceOutputStandard, output);
     output.Normal = UnityObjectToWorldNormal(objectNormal);
@@ -186,7 +188,8 @@ float4 ELRaycastShadowCasterFragment(ELRaycastBaseFragmentInput input) : SV_Targ
     float3 objectNormalUnused;
     float materialUnused;
     uint iterationsUnused;
-    bool hit = ELFragmentRaycast(input, objectPos, objectNormalUnused, materialUnused, iterationsUnused);
+    float reachUnused;
+    bool hit = ELFragmentRaycast(input, objectPos, objectNormalUnused, materialUnused, iterationsUnused, reachUnused);
     clip(hit ? 1.0 : -1.0);
 
     // Has to be called `v` because `TRANSFER_SHADOW_CASTER` sucks

--- a/ELRaycastBaseInputOutput.cginc
+++ b/ELRaycastBaseInputOutput.cginc
@@ -83,6 +83,10 @@ struct ELRaycastBaseFragmentInput
      * Ray iterations (I tried to name it iterations but it conflicts with a shader keyword).
      */            
     uint its : TEXCOORD6;
+    /**
+     * Distance of ray
+     */
+    float reach : TEXCOORD7;
 };
 
 /**

--- a/ELRaycastBaseInputOutput.cginc
+++ b/ELRaycastBaseInputOutput.cginc
@@ -71,6 +71,18 @@ struct ELRaycastBaseFragmentInput
      * The direction of the ray in object space.
      */
     float3 objectRayDirection   : TEXCOORD3;
+    /**
+     * This should be done in the vertex shader.
+     */
+    #ifndef SPHERICAL_HARMONICS_PER_PIXEL
+        #ifndef LIGHTMAP_ON
+            #if UNITY_SHOULD_SAMPLE_SH
+            half3 sh : TEXCOORD4;
+            #endif
+        #endif
+    #endif    
+    
+
 };
 
 /**

--- a/ELRaycastBaseInputOutput.cginc
+++ b/ELRaycastBaseInputOutput.cginc
@@ -72,16 +72,13 @@ struct ELRaycastBaseFragmentInput
      */
     float3 objectRayDirection   : TEXCOORD3;
     /**
+     * Lightmap.
+     */    
+    float4 lmap : TEXCOORD4;
+    /**
      * This should be done in the vertex shader.
      */
-    #ifndef SPHERICAL_HARMONICS_PER_PIXEL
-        #ifndef LIGHTMAP_ON
-            #if UNITY_SHOULD_SAMPLE_SH
-            half3 sh : TEXCOORD4;
-            #endif
-        #endif
-    #endif    
-    
+    half3 sh : TEXCOORD5;
 
 };
 

--- a/ELRaycastBaseInputOutput.cginc
+++ b/ELRaycastBaseInputOutput.cginc
@@ -76,10 +76,13 @@ struct ELRaycastBaseFragmentInput
      */    
     float4 lmap : TEXCOORD4;
     /**
-     * This should be done in the vertex shader.
-     */
+     * Spherical harmonics from vertex shading.
+     */        
     half3 sh : TEXCOORD5;
-
+    /**
+     * Ray iterations (I tried to name it iterations but it conflicts with a shader keyword).
+     */            
+    uint its : TEXCOORD6;
 };
 
 /**

--- a/ELRaymarchBase.cginc
+++ b/ELRaymarchBase.cginc
@@ -5,9 +5,9 @@
 #include "ELRaymarchCommon.cginc"
 
 // Implementing function defined in `ELRaycastBase.cginc`
-bool ELRaycast(ELRay ray, out float3 objectPos, out float3 objectNormal, out float material, out uint its)
+bool ELRaycast(ELRay ray, out float3 objectPos, out float3 objectNormal, out float material, out uint its, out float reach)
 {
-    bool hit = ELRaymarch(ray, objectPos, material, its);
+    bool hit = ELRaymarch(ray, objectPos, material, its, reach);
 
     // Avoid potential multiple map calls if it didn't hit at all
     UNITY_BRANCH

--- a/ELRaymarchBase.cginc
+++ b/ELRaymarchBase.cginc
@@ -5,9 +5,9 @@
 #include "ELRaymarchCommon.cginc"
 
 // Implementing function defined in `ELRaycastBase.cginc`
-bool ELRaycast(ELRay ray, out float3 objectPos, out float3 objectNormal, out float material)
+bool ELRaycast(ELRay ray, out float3 objectPos, out float3 objectNormal, out float material, out uint its)
 {
-    bool hit = ELRaymarch(ray, objectPos, material);
+    bool hit = ELRaymarch(ray, objectPos, material, its);
 
     // Avoid potential multiple map calls if it didn't hit at all
     UNITY_BRANCH

--- a/ELRaymarchCommon.cginc
+++ b/ELRaymarchCommon.cginc
@@ -69,13 +69,14 @@ float3 ELRaymarchNormal(float3 objectPos)
 #define MAX_DISTANCE 200.0
 
 
-bool ELRaymarch(ELRay ray, out float3 objectPos, out float material, out uint its)
+bool ELRaymarch(ELRay ray, out float3 objectPos, out float material, out uint its, out float reach)
 {
     float2 mapResult;
 
     // to silence warnings about not initialising output values :|
     objectPos = float3(0.0, 0.0, 0.0);
     material = 0.0;
+    reach = 0.0;
 
     float3 boxMin;
     float3 boxMax;
@@ -92,6 +93,7 @@ bool ELRaymarch(ELRay ray, out float3 objectPos, out float material, out uint it
     {
         mapResult = ELMap(ray.position);
         objectPos = ray.position;
+        reach = ray.reach;
         its = i;
 
         // XXX: Do we even still need MAX_DISTANCE?

--- a/ELRaymarchCommon.cginc
+++ b/ELRaymarchCommon.cginc
@@ -64,9 +64,17 @@ float3 ELRaymarchNormal(float3 objectPos)
     #endif
 }
 
+#ifndef MAX_STEPS
 #define MAX_STEPS 200
+#endif
+
+#ifndef MIN_DISTANCE
 #define MIN_DISTANCE 0.0001
+#endif
+
+#ifndef MAX_DISTANCE
 #define MAX_DISTANCE 200.0
+#endif
 
 
 bool ELRaymarch(ELRay ray, out float3 objectPos, out float material, out uint its, out float reach)

--- a/ELRaymarchCommon.cginc
+++ b/ELRaymarchCommon.cginc
@@ -69,7 +69,7 @@ float3 ELRaymarchNormal(float3 objectPos)
 #define MAX_DISTANCE 200.0
 
 
-bool ELRaymarch(ELRay ray, out float3 objectPos, out float material)
+bool ELRaymarch(ELRay ray, out float3 objectPos, out float material, out uint its)
 {
     float2 mapResult;
 
@@ -92,6 +92,7 @@ bool ELRaymarch(ELRay ray, out float3 objectPos, out float material)
     {
         mapResult = ELMap(ray.position);
         objectPos = ray.position;
+        its = i;
 
         // XXX: Do we even still need MAX_DISTANCE?
         if (mapResult.x > MAX_DISTANCE || ray.reach > maxReach)

--- a/ELScuttledUnityLighting.cginc
+++ b/ELScuttledUnityLighting.cginc
@@ -85,14 +85,14 @@ float4 ELSurfaceFragment(SurfaceOutputStandard surfaceOutput, ELRaycastBaseFragm
     gi.indirect.diffuse = 0;
     gi.indirect.specular = 0;
 #ifdef USING_DIRECTIONAL_LIGHT
-    //I think length(worldLightDir) should work by itself but I'm not 100% sure so let's just adapt Xiexe XStoon's method instead: https://github.com/Xiexe/Xiexes-Unity-Shaders
+    // If we have no directional light, compare diffuse irradiance (SHAx) with ambience (w term) to determine if ambient lighting is sufficient to warrant simuating lighting.
     if(length(unity_SHAr.xyz*unity_SHAr.w + unity_SHAg.xyz*unity_SHAg.w + unity_SHAb.xyz*unity_SHAb.w) == 0 && length(worldLightDir) < 0.1)
     {
         float fakeSwitch = sqrt(1-_WorldSpaceLightPos0.w*_WorldSpaceLightPos0.w);
         float fakeIntensity = clamp(length(_LightColor0.rgb), 0.55, 1);
-        // Better lighting.
+        // Realistic lighting.
         gi.light.color = _LightColor0.rgb + ShadeSH9(float4(worldNormal,1)) * fakeIntensity * fakeSwitch;
-        // Only ambient.
+        // Toon lighting.
         //gi.light.color = _LightColor0.rgb + float3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w) + float3(unity_SHBr.z, unity_SHBg.z, unity_SHBb.z) / 3.0;
         gi.light.dir = worldLightDir + float3(0.33333333,0.66666666,0.66666666) * fakeSwitch;
     } else {

--- a/ELScuttledUnityLighting.cginc
+++ b/ELScuttledUnityLighting.cginc
@@ -93,8 +93,12 @@ float4 ELSurfaceFragment(SurfaceOutputStandard surfaceOutput, ELRaycastBaseFragm
     giInput.worldPos = worldPos;
     giInput.worldViewDir = worldViewDir;
     giInput.atten = attenuation;
+    #if defined(LIGHTMAP_ON) || defined(DYNAMICLIGHTMAP_ON)
+        giInput.lightmapUV = input.lmap;
+    #else
     giInput.lightmapUV = 0.0;
-    #if UNITY_SHOULD_SAMPLE_SH
+    #endif
+    #if UNITY_SHOULD_SAMPLE_SH && !UNITY_SAMPLE_FULL_SH_PER_PIXEL
         #ifdef SPHERICAL_HARMONICS_PER_PIXEL
         giInput.ambient = ShadeSHPerPixel(worldNormal, 0.0, worldPos);
         #else

--- a/ELScuttledUnityLighting.cginc
+++ b/ELScuttledUnityLighting.cginc
@@ -90,7 +90,10 @@ float4 ELSurfaceFragment(SurfaceOutputStandard surfaceOutput, ELRaycastBaseFragm
     {
         float fakeSwitch = sqrt(1-_WorldSpaceLightPos0.w*_WorldSpaceLightPos0.w);
         float fakeIntensity = clamp(length(_LightColor0.rgb), 0.55, 1);
-        gi.light.color = _LightColor0.rgb + ShadeSH9(float4(0,0,0,1)) * fakeIntensity * fakeSwitch;
+        // Better lighting.
+        gi.light.color = _LightColor0.rgb + ShadeSH9(float4(worldNormal,1)) * fakeIntensity * fakeSwitch;
+        // Only ambient.
+        //gi.light.color = _LightColor0.rgb + float3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w) + float3(unity_SHBr.z, unity_SHBg.z, unity_SHBb.z) / 3.0;
         gi.light.dir = worldLightDir + float3(0.33333333,0.66666666,0.66666666) * fakeSwitch;
     } else {
         gi.light.color = _LightColor0.rgb;// * attenuation;


### PR DESCRIPTION
No need for Lux or XSToon now. 

VRC worlds usually just have an ambient probe. This adds in simulated lighting in those conditions (if ambient lighting is bright enough to cause the object to get lit). 

Original test case (using latest in ambient-lighting-fixes branch):
![image](https://user-images.githubusercontent.com/72054736/110637283-d84b4b00-8172-11eb-9064-265b2057ba85.png)

Test case using my changes:

![image](https://user-images.githubusercontent.com/72054736/110637503-1183bb00-8173-11eb-99fa-e62bf9aef059.png)

